### PR TITLE
redirect sig layers to report

### DIFF
--- a/R/conr-server.R
+++ b/R/conr-server.R
@@ -64,9 +64,9 @@ conr_server <- function() {
       data_sf_r = reactive({
         mapping_l$data_sf()
       }),
-      threat_sig_r = reactive({
-        mapping_l$threat_sig()
-      }),
+      # threat_sig_r = reactive({
+      #   mapping_l$threat_sig()
+      # }),
       polygon_r = reactive(data_rv$polygon)
     )
 

--- a/R/module-report.R
+++ b/R/module-report.R
@@ -27,7 +27,7 @@ summary_report_ui <- function(id) {
 
     
     bslib::navs_pill_card(
-      title = "Report",
+      # title = "Report",
       nav(
         title = "by species",
         fluidRow(
@@ -89,7 +89,7 @@ summary_report_server <- function(id,
                                   data_r = reactive(NULL),
                                   results_r = reactive(NULL),
                                   data_sf_r = reactive(NULL),
-                                  threat_sig_r = reactive(NULL),
+                                  # threat_sig_r = reactive(NULL),
                                   polygon_r = reactive(NULL)) {
   moduleServer(
     id = id,
@@ -101,6 +101,9 @@ summary_report_server <- function(id,
           length(results_r()) > 0,
           !is.null(results_r()$results$taxa)
         )
+        
+        print(results_r()$locations)
+        
         species <- results_r()$results$taxa
         shinyWidgets::updateVirtualSelect(
           inputId = "taxa",
@@ -121,6 +124,8 @@ summary_report_server <- function(id,
         data_sf <- req(data_sf_r())
         results <- req(results_r())
         req(input$taxa)
+        
+        print(results$locations$threat_list)
 
         tmp <- tempfile(fileext = ".html")
 
@@ -137,7 +142,7 @@ summary_report_server <- function(id,
                 filter(tax == input$taxa),
               res_eoo = results$eoo_res$spatial %>%
                 filter(tax == input$taxa),
-              threat_sig = threat_sig_r(),
+              threat_sig = results$locations$threat_list,
               parameters = results$parameters,
               res_loc = results$locations$locations_poly %>%
                 filter(tax == input$taxa),
@@ -183,7 +188,7 @@ summary_report_server <- function(id,
                   filter(tax == input$taxa),
                 res_eoo = results$eoo_res$spatial %>%
                   filter(tax == input$taxa),
-                threat_sig = threat_sig_r(),
+                threat_sig = results$locations$threat_list,
                 parameters = results$parameters,
                 res_loc = results$locations$locations_poly %>%
                   filter(tax == input$taxa),
@@ -219,7 +224,7 @@ summary_report_server <- function(id,
             params = list(
               data = data_r(),
               polygon_rv = polygon_r(),
-              threat_sig = threat_sig_r(),
+              threat_sig = results$locations$threat_list,
               parameters = results$parameters,
               results = results$results,
               resol = 2

--- a/inst/reports/species_report.Rmd
+++ b/inst/reports/species_report.Rmd
@@ -220,6 +220,38 @@ if (nrow(params$res_loc %>% filter(threat != "not_threatened")) > 0) {
 }
 
 
+if (any(!is.na(params$threat_sig))) {
+  
+  
+  
+  for (i in 1:length(params$threat_sig)) {
+    
+    
+    threat_layer <- st_transform(params$threat_sig[[i]], 4326)
+  
+    group_lf <- c(group_lf, names(params$threat_sig)[i])
+    
+    leaf_map <-
+      leaf_map %>%
+      leaflet::addPolygons(
+        data = threat_layer,
+        fillColor = "grey",
+        weight = 1,
+        opacity = 0.2,
+        color = "blue",
+        dashArray = "1",
+        fillOpacity = 0.4,
+        group = names(params$threat_sig)[i],
+        label = names(params$threat_sig)[i]
+      )
+    
+  }
+  
+  
+  
+}
+
+
 leaf_map <- leaf_map %>%
   leaflet::addLayersControl(
     baseGroups = c("OSM", "Esri", "Open Topo Map"),


### PR DESCRIPTION
Pour rediriger les données spatiales générées par une fonction de ConR vers la génération des rapports.